### PR TITLE
Updated YTNoCommunityPosts (Code Improvements & Localization Support)

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1,17 +1,19 @@
 #import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <rootless.h>
 
-@interface YTCollectionViewCell : UICollectionViewCell
-@end
+#define LOC(x) [tweakBundle localizedStringForKey:x value:nil table:nil]
 
-@interface YTSettingsCell : YTCollectionViewCell
-@end
+NSBundle *tweakBundle;
+
+@class YTSettingsCell;
 
 @interface YTSettingsSectionItem : NSObject
-@property BOOL hasSwitch;
-@property BOOL switchVisible;
-@property BOOL on;
-@property BOOL (^switchBlock)(YTSettingsCell *, BOOL);
-@property int settingItemId;
+@property (nonatomic) BOOL hasSwitch;
+@property (nonatomic) BOOL switchVisible;
+@property (nonatomic) BOOL on;
+@property (nonatomic, copy) BOOL (^switchBlock)(YTSettingsCell *, BOOL);
+@property (nonatomic) int settingItemId;
 - (instancetype)initWithTitle:(NSString *)title titleDescription:(NSString *)titleDescription;
 @end
 
@@ -25,37 +27,59 @@
 @interface YTCommentNode : NSObject
 @end
 
+extern NSBundle *YTNoCommunityPostsBundle();
+
+NSBundle *YTNoCommunityPostsBundle() {
+    static NSBundle *bundle = nil;
+    static dispatch_once_t onceToken;
+	dispatch_once(&onceToken, ^{
+        NSString *tweakBundlePath = [[NSBundle mainBundle] pathForResource:@"YTNoCommunityPosts" ofType:@"bundle"];
+        if (tweakBundlePath)
+            bundle = [NSBundle bundleWithPath:tweakBundlePath];
+        else
+            bundle = [NSBundle bundleWithPath:ROOT_PATH_NS(@"/Library/Application Support/YTNoCommunityPosts.bundle")];
+    });
+    return bundle;
+}
+
+%ctor {
+    tweakBundle = YTNoCommunityPostsBundle();
+}
 
 %hook YTSettingsViewController
 - (void)setSectionItems:(NSMutableArray <YTSettingsSectionItem *> *)sectionItems forCategory:(NSInteger)category title:(NSString *)title titleDescription:(NSString *)titleDescription headerHidden:(BOOL)headerHidden {
-	if (category == 1) {
-		YTSettingsSectionItem *commpost = [[%c(YTSettingsSectionItem) alloc] initWithTitle:@"Show Community Posts"
-		titleDescription:@"Enables viewing community posts in app"];
-		commpost.hasSwitch = YES;
-		commpost.switchVisible = YES;
-		commpost.on = [[NSUserDefaults standardUserDefaults] boolForKey:@"show_comm_posts"];
-		commpost.switchBlock = ^BOOL (YTSettingsCell *cell, BOOL enabled) {
-			[[NSUserDefaults standardUserDefaults] setBool:enabled forKey:@"show_comm_posts"];
-			return YES;
-		};
-		[sectionItems addObject:commpost];
-	}
-	%orig(sectionItems, category, title, titleDescription, headerHidden);
+
+    if (category == 1) {
+        YTSettingsSectionItem *commpost = [[%c(YTSettingsSectionItem) alloc] initWithTitle:LOC(@"HIDE_COMMUNITY_POSTS") titleDescription:LOC(@"HIDE_COMMUNITY_POSTS_DESC")];
+        commpost.hasSwitch = YES;
+        commpost.switchVisible = YES;
+        commpost.on = ![[NSUserDefaults standardUserDefaults] boolForKey:@"hide_comm_posts"];
+        commpost.switchBlock = ^BOOL (YTSettingsCell *cell, BOOL enabled) {
+            [[NSUserDefaults standardUserDefaults] setBool:!enabled forKey:@"hide_comm_posts"];
+            return YES;
+        };
+        [sectionItems addObject:commpost];
+    }
+    %orig(sectionItems, category, title, titleDescription, headerHidden);
 }
 %end
 
 %hook YTAsyncCollectionView
 - (id)cellForItemAtIndexPath:(NSIndexPath *)indexPath {
-	if (![[NSUserDefaults standardUserDefaults] boolForKey:@"show_comm_posts"]) {
-		UICollectionViewCell *cell = %orig;
-		if ([cell isKindOfClass:NSClassFromString(@"_ASCollectionViewCell")]) {
-			_ASCollectionViewCell *cell = %orig;		
-			NSString *result = [[[[cell node] accessibilityElements] valueForKey:@"description"] componentsJoinedByString:@""];
-			if ([result rangeOfString:@"id.ui.backstage.post"].location != NSNotFound) {
-				[self deleteItemsAtIndexPaths:[NSArray arrayWithObject:indexPath]];
-			}
-		}
-	}
-	return %orig;
+    if ([[NSUserDefaults standardUserDefaults] boolForKey:@"hide_comm_posts"]) {
+        return %orig;
+    }  
+    UICollectionViewCell *cell = %orig;
+    
+    if ([cell isKindOfClass:NSClassFromString(@"_ASCollectionViewCell")]) {
+        _ASCollectionViewCell *asCell = (_ASCollectionViewCell *)cell;
+        
+        NSString *result = [[[[asCell node] accessibilityElements] valueForKey:@"description"] componentsJoinedByString:@""];
+        
+        if ([result rangeOfString:@"id.ui.backstage.post"].location != NSNotFound) {
+            [self deleteItemsAtIndexPaths:@[indexPath]];
+        }
+    }
+    return cell;
 }
 %end

--- a/layout/Library/Application Support/YTNoCommunityPosts.bundle/en.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTNoCommunityPosts.bundle/en.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+// YTNoCommunityPosts Localization
+
+"HIDE_COMMUNITY_POSTS" = "Hide Community Posts";
+"HIDE_COMMUNITY_POSTS_DESC" = "Disables viewing community posts in the app.";

--- a/layout/Library/Application Support/YTNoCommunityPosts.bundle/fr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTNoCommunityPosts.bundle/fr.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+// YTNoCommunityPosts Localization
+
+"HIDE_COMMUNITY_POSTS" = "Afficher les publications de l'onglet communauté";
+"HIDE_COMMUNITY_POSTS_DESC" = "Permet de voir les publications de l'onglet communauté dans l'application.";

--- a/layout/Library/Application Support/YTNoCommunityPosts.bundle/ja.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTNoCommunityPosts.bundle/ja.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+// YTNoCommunityPosts Localization
+
+"HIDE_COMMUNITY_POSTS" = "コミュニティ投稿を表示";
+"HIDE_COMMUNITY_POSTS_DESC" = "アプリ内でコミュニティ投稿の表示を有効にします";

--- a/layout/Library/Application Support/YTNoCommunityPosts.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/YTNoCommunityPosts.bundle/tr.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+// YTNoCommunityPosts Localization
+
+"HIDE_COMMUNITY_POSTS" = "Topluluk Gönderilerini Göster";
+"HIDE_COMMUNITY_POSTS_DESC" = "Uygulamada topluluk gönderilerinin görüntülenmesini sağlar.";


### PR DESCRIPTION
Hey @michael-winay I have changed the YTNoCommunityPosts Tweak and here’s what I’ve added.
- Code Improvements
   - Organized & Cleaned Up Code
   - Updated all of the Properties to include (nonatomic)
   - Inverted the option “Show Community Posts” to be “Hide Community Posts”
- Localization Support
   - English Localization (Localized by **arichorn**)
   - Japan Localization (Localized by **SKIEDS**)
   - Turkish Localization (Localized by **gototheskinny**)
   - French Localization (Localized by **Balackburn**)
   
But I also recommend updating the Makefile. Building with iOS 7 may cause some crashing in some cases